### PR TITLE
add McAffee Web Gateway virus detection headers to be used in impleme…

### DIFF
--- a/src/main/java/com/github/toolarium/icap/client/dto/ICAPConstants.java
+++ b/src/main/java/com/github/toolarium/icap/client/dto/ICAPConstants.java
@@ -32,5 +32,10 @@ public interface ICAPConstants {
     String HEADER_KEY_X_REQUEST_MESSAGE_DIGEST = "X-Request-Message-Digest";    
     String HEADER_KEY_X_RESPONSE_MESSAGE_DIGEST = "X-Response-Message-Digest";
     String HEADER_KEY_X_IDENTICAL_CONTENT = "X-Resource-Identical-Content";
-    
+
+    // McAffee Web Gateway ICAP headers
+    String HEADER_KEY_X_BLOCK_REASON = "X-Block-Reason";
+    String HEADER_KEY_X_VIRUS_NAME = "X-Virus-Name";
+    String HEADER_KEY_X_BLOCK_RESULT = "X-WWBlockResult";
+
 }

--- a/src/main/java/com/github/toolarium/icap/client/impl/ICAPClientImpl.java
+++ b/src/main/java/com/github/toolarium/icap/client/impl/ICAPClientImpl.java
@@ -100,8 +100,8 @@ public class ICAPClientImpl implements ICAPClient {
             }
             
             int serverPreviewSize = 1024;
-            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_PREVIEW) 
-                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW) != null 
+            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_PREVIEW)
+                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW) != null
                     && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW).size() > 0) {
                 try {
                     serverPreviewSize = Integer.parseInt(icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW).get(0));
@@ -197,8 +197,12 @@ public class ICAPClientImpl implements ICAPClient {
                         threadInformation += "- " + e.getKey() + ": " + e.getValue() + "\n";
                     }
                 }
-                
-                if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_INFECTION_FOUND) || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIOLATIONS_FOUND)) {
+
+                if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_INFECTION_FOUND)
+                    || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIOLATIONS_FOUND)
+                    || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_REASON)
+                    || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_NAME)
+                    || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_RESULT)) {
                     String errorContent = "";
                     if (resourceResponse != null 
                             && icapHeaderInformation.getHeaders().containsKey(ICAPConstants.HEADER_KEY_ENCAPSULATED) 


### PR DESCRIPTION
When using the ICAP from McAffee Web Gateway, the X-Block-Header is not sent when a virus is found and so, no Exception is thrown. Other headers seem to be relevant here (please confer my email to Patrick on June 12th this year for a complete log):
```
2023-06-12 12:10:46,881 DEBUG [com.git.too.ica.cli.imp.ChunkedInputStream] (executor-thread-2) ADE3F61C - HTTP headers:
ICAP/1.0 200 OK
ISTag: "008080-0.2.82-10738-117660-00"
Encapsulated: res-hdr=0, res-body=122
X-Media-Type: text/plain
X-Virus-Name: EICAR test file
X-Block-Reason: Malware found
X-WWBlockResult: 80
```

Please include at least one of my suggested headers so we can use the Toolarium ICAP client in conjunction with our McAffee Web Gateway.
