### PR TITLE
Add ability to set the SoTimeout on sockets

### DIFF
--- a/src/main/java/com/github/toolarium/icap/client/ICAPConnectionManager.java
+++ b/src/main/java/com/github/toolarium/icap/client/ICAPConnectionManager.java
@@ -13,29 +13,36 @@ import java.net.UnknownHostException;
 
 /**
  * Defines the connection manager
- * 
+ *
  * @author patrick
  */
 public interface ICAPConnectionManager {
-    
+
     /**
      * Create a socket connection to the ICAP.
      *
      * @param hostname the name of the host to connect
      * @param port the port
      * @param secureConnection true to use secured SSL connection
-     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block. 
+     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block.
      * @return the socket / SSL socket
      * @throws UnknownHostException In case of unknown host
      * @throws IOException In case of an I/O error
      */
     Socket createSocket(String hostname, int port, boolean secureConnection, Integer maxRequestTimeout) throws UnknownHostException, IOException;
 
-    
+
     /**
      * Define the default socket timeout in milliseconds or null. A timeout of null or zero are interpreted as an infinite timeout. The connection will then block.
      *
      * @param defaultSocketTimeout the default socket timeout in milliseconds or null.
      */
     void setDefaultSocketTimeout(Integer defaultSocketTimeout);
+
+    /**
+     * Define the default socket read timeout in milliseconds or null. A timeout of null or zero are interpreted as an infinite timeout.
+     *
+     * @param defaultReadTimeout the default socket timeout in milliseconds or null.
+     */
+    void setDefaultReadTimeout(int defaultReadTimeout);
 }

--- a/src/main/java/com/github/toolarium/icap/client/impl/ICAPConnectionManagerImpl.java
+++ b/src/main/java/com/github/toolarium/icap/client/impl/ICAPConnectionManagerImpl.java
@@ -16,18 +16,19 @@ import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Implements the {@link ICAPConnectionManager}.
- * 
+ *
  * @author patrick
  */
 public class ICAPConnectionManagerImpl implements ICAPConnectionManager {
     private Integer defaultSocketTimeout;
+    private int defaultReadTimeout = 0;
 
     /**
      * @see com.github.toolarium.icap.client.ICAPConnectionManager#createSocket(java.lang.String, int, boolean, java.lang.Integer)
      */
     @Override
     public Socket createSocket(String hostname, int port, boolean secureConnection, Integer maxRequestTimeout) throws UnknownHostException, IOException {
-        
+
         if (!secureConnection) {
             return createUnsecureSocket(hostname, port, maxRequestTimeout);
         }
@@ -44,19 +45,29 @@ public class ICAPConnectionManagerImpl implements ICAPConnectionManager {
         this.defaultSocketTimeout = defaultSocketTimeout;
     }
 
-    
+
+    /**
+     * @see com.github.toolarium.icap.client.ICAPConnectionManager#setDefaultReadTimeout(int)
+     */
+    @Override
+    public void setDefaultReadTimeout(int defaultReadTimeout) {
+        this.defaultReadTimeout = defaultReadTimeout;
+    }
+
+
     /**
      * Create a simple socket
-     * 
+     *
      * @param hostname the name of host
      * @param port the port
-     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block. 
+     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block.
      * @return the socket
      * @throws UnknownHostException In case of unknown host
      * @throws IOException In case of an I/O error
      */
     protected Socket createUnsecureSocket(String hostname, int port, Integer maxRequestTimeout) throws UnknownHostException, IOException {
         Socket socket = new Socket();
+        socket.setSoTimeout(defaultReadTimeout);
         socket.connect(new InetSocketAddress(hostname,port), getRequestSocketTimeout(maxRequestTimeout));
         return socket;
     }
@@ -64,10 +75,10 @@ public class ICAPConnectionManagerImpl implements ICAPConnectionManager {
 
     /**
      * Create a secure socket
-     * 
+     *
      * @param hostname the name of host
      * @param port the port
-     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block. 
+     * @param maxRequestTimeout the max request timeout in milliseconds. By default there is no timeout set (null). A timeout of null or zero are interpreted as an infinite timeout. The connection will then block.
      * @return the socket
      * @throws UnknownHostException In case of unknown host
      * @throws IOException In case of an I/O error
@@ -75,6 +86,7 @@ public class ICAPConnectionManagerImpl implements ICAPConnectionManager {
     protected Socket createSecureSocket(String hostname, int port, Integer maxRequestTimeout) throws UnknownHostException, IOException {
         SSLSocketFactory factory = (SSLSocketFactory)SSLSocketFactory.getDefault();
         Socket sslSocket = (SSLSocket)factory.createSocket();
+        sslSocket.setSoTimeout(defaultReadTimeout);
         sslSocket.connect(new InetSocketAddress(hostname,port), getRequestSocketTimeout(maxRequestTimeout));
         return sslSocket;
     }

--- a/src/test/java/com/github/toolarium/icap/client/ICAPSocketTimeoutTest.java
+++ b/src/test/java/com/github/toolarium/icap/client/ICAPSocketTimeoutTest.java
@@ -5,29 +5,36 @@
  */
 package com.github.toolarium.icap.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.toolarium.icap.client.dto.ICAPMode;
 import com.github.toolarium.icap.client.dto.ICAPRequestInformation;
 import com.github.toolarium.icap.client.dto.ICAPResource;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * Test socket timeout
- * 
+ * Test socket timeouts
+ *
  * @author patrick
  */
 public class ICAPSocketTimeoutTest {
     private static final String RESOURCE_COULD_NOT_BE_ACCESSED = "Resource could not be accessed: ";
-    private static final String LOCALHOST = "localhost"; 
-    private static final String SERVICENAME = "srv_clamav"; 
+    private static final String LOCALHOST = "localhost";
+    private static final String SERVICENAME = "srv_clamav";
     private static final Logger LOG = LoggerFactory.getLogger(ICAPSocketTimeoutTest.class);
 
-    
     /**
      * Socket timeout
      */
@@ -36,12 +43,12 @@ public class ICAPSocketTimeoutTest {
         LOG.debug("START");
         ICAPClientFactory.getInstance().getICAPConnectionManager().setDefaultSocketTimeout(10);
         final int port = 1344;
-                
+
         try {
             ByteArrayInputStream resourceInputStream = new ByteArrayInputStream(new byte[] {});
             ICAPClientFactory.getInstance().getICAPClient(LOCALHOST, port, SERVICENAME)
-                 .validateResource(ICAPMode.RESPMOD, 
-                                   new ICAPRequestInformation("userb", "emptyfile").addCustomHeader("Test", "Header").maxRequestTimeout(1), 
+                 .validateResource(ICAPMode.RESPMOD,
+                                   new ICAPRequestInformation("userb", "emptyfile").addCustomHeader("Test", "Header").maxRequestTimeout(1),
                                    new ICAPResource("build/test-emptyfile.com", resourceInputStream, 0));
         } catch (Exception ioe) { // I/O error
             LOG.warn(RESOURCE_COULD_NOT_BE_ACCESSED + ioe.getMessage(), ioe);
@@ -50,7 +57,53 @@ public class ICAPSocketTimeoutTest {
 
         LOG.debug("END");
     }
-    
+
+    /**
+     * Socket read timeout
+     *
+     * @throws IOException if the server socket cannot be opened
+     */
+    @Test
+    public void testSocketReadTimeout() throws IOException {
+        int port = 12345;
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            // start dummy server that accepts connections, but does not respond
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
+                try (Socket s = serverSocket.accept()) {
+                    // keep connection open, but do not send any response (simulates a hanging system)
+                    InputStream is = s.getInputStream();
+                    // read all data from socket
+                    byte[] buffer = new byte[128];
+                    int read;
+                    while ((read = is.read(buffer)) != -1) {
+                        String output = new String(buffer, 0, read);
+                        LOG.trace(output);
+                    }
+                } catch (Exception e) {
+                    // ignore any server side exceptions
+                }
+            });
+
+            // Client: Open icap connection to dummy server
+            ICAPClientFactory icapClientFactory = ICAPClientFactory.getInstance();
+            icapClientFactory.getICAPConnectionManager().setDefaultReadTimeout(1); // <== this is the timeout we test
+
+            Exception e = assertThrows(SocketTimeoutException.class,
+                () -> icapClientFactory.getICAPClient(
+                    "icap://localhost:" + port + "/reqmod", 3600
+                    ).validateResource(
+                        ICAPMode.RESPMOD,
+                        new ICAPRequestInformation(),
+                        new ICAPResource("dummy resource",
+                            new ByteArrayInputStream("dummy data".getBytes()), 10)
+                    )
+            );
+            assertEquals("Read timed out", e.getMessage());
+
+            executor.shutdownNow();
+        }
+    }
 
     /**
      * Test connection
@@ -58,7 +111,7 @@ public class ICAPSocketTimeoutTest {
     @Test
     public void testConnection() {
         int port = 1345; // invalid port
-        
+
         try {
             String hostName = "localhost1";
             ICAPClientFactory.getInstance().getICAPClient(hostName, port, SERVICENAME, false);


### PR DESCRIPTION
With the current implementation we get a exception if a connection cannot be established within the given timeout interval (socket timeout), but we do not get an exception if the connection is already established but the server stops responding (read timeout). With this pull request we introduce the configuration and usage of the socket's SoTimeout that allows reacting to the latter scenarios.

- add setDefaultReadTimeout method to ICAPConnectionManager
- set SoTimeout within createUnsecureSocket and createSecureSocket in ICAPConnectionManagerImpl using the value defaultReadTimeout set with setDefaultReadTimeout
- add test