### PR TITLE
Added UnknownIOException to access information returned in some cases by ICAP Server.

### DIFF
--- a/src/main/java/com/github/toolarium/icap/client/exception/UnknownIOException.java
+++ b/src/main/java/com/github/toolarium/icap/client/exception/UnknownIOException.java
@@ -1,0 +1,42 @@
+/*
+ * UnknownIOException.java
+ *
+ * Copyright by toolarium, all rights reserved.
+ */
+package com.github.toolarium.icap.client.exception;
+
+import com.github.toolarium.icap.client.dto.ICAPHeaderInformation;
+
+import java.io.IOException;
+
+/**
+ * The unknown IO exception.
+ *
+ * @author Michael Farley
+ */
+public class UnknownIOException extends IOException {
+    private static final long serialVersionUID = 5711527857339125277L;
+    private final ICAPHeaderInformation icapHeaderInformation;
+
+
+    /**
+     * Constructor for ICAPException
+     *
+     * @param message the message
+     * @param icapHeaderInformation the ICAP header information
+     */
+    public UnknownIOException(String message, ICAPHeaderInformation icapHeaderInformation) {
+        super(message);
+        this.icapHeaderInformation = icapHeaderInformation;
+    }
+
+
+    /**
+     * Get the ICAP response
+     *
+     * @return the ICAP response
+     */
+    public ICAPHeaderInformation getICAPHeaderInformation() {
+        return icapHeaderInformation;
+    }
+}

--- a/src/main/java/com/github/toolarium/icap/client/impl/ICAPClientImpl.java
+++ b/src/main/java/com/github/toolarium/icap/client/impl/ICAPClientImpl.java
@@ -7,16 +7,14 @@ package com.github.toolarium.icap.client.impl;
 
 import com.github.toolarium.icap.client.ICAPClient;
 import com.github.toolarium.icap.client.ICAPConnectionManager;
-import com.github.toolarium.icap.client.dto.ICAPConstants;
-import com.github.toolarium.icap.client.dto.ICAPHeaderInformation;
-import com.github.toolarium.icap.client.dto.ICAPMode;
-import com.github.toolarium.icap.client.dto.ICAPRemoteServiceConfiguration;
-import com.github.toolarium.icap.client.dto.ICAPRequestInformation;
-import com.github.toolarium.icap.client.dto.ICAPResource;
-import com.github.toolarium.icap.client.dto.ICAPServiceInformation;
+import com.github.toolarium.icap.client.dto.*;
 import com.github.toolarium.icap.client.exception.ContentBlockedException;
+import com.github.toolarium.icap.client.exception.UnknownIOException;
 import com.github.toolarium.icap.client.impl.dto.ICAPRemoteServiceConfigurationImpl;
 import com.github.toolarium.icap.client.util.ICAPClientUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,8 +29,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -70,52 +66,52 @@ public class ICAPClientImpl implements ICAPClient {
 
 
     /**
-     * @see com.github.toolarium.icap.client.ICAPClient#supportCompareVerifyIdenticalContent(boolean)
+     * @see ICAPClient#supportCompareVerifyIdenticalContent(boolean)
      */
-    @Override    
+    @Override
     public ICAPClient supportCompareVerifyIdenticalContent(boolean supportCompareVerifyIdenticalContent) {
         this.supportCompareVerifyIdenticalContent = supportCompareVerifyIdenticalContent;
         return this;
     }
 
-    
+
     /**
-     * @see com.github.toolarium.icap.client.ICAPClient#options()
+     * @see ICAPClient#options()
      */
-    @Override    
+    @Override
     public ICAPRemoteServiceConfiguration options() throws IOException {
         return options(new ICAPRequestInformation());
     }
-    
+
 
     /**
-     * @see com.github.toolarium.icap.client.ICAPClient#options()
+     * @see ICAPClient#options()
      */
-    @Override    
+    @Override
     public ICAPRemoteServiceConfiguration options(final ICAPRequestInformation requestInformation) throws IOException {
         if (remoteServiceConfiguration != null) {
             return remoteServiceConfiguration;
         }
-        
+
         validateRequestInformation(requestInformation);
         final String requestIdentifier = createRequestIdentifier("options", null);
-        try (ICAPSocket icapSocket = new ICAPSocket(connectionManager, requestIdentifier, serviceInformation.getHostName(), serviceInformation.getServicePort(), 
+        try (ICAPSocket icapSocket = new ICAPSocket(connectionManager, requestIdentifier, serviceInformation.getHostName(), serviceInformation.getServicePort(),
                                                     serviceInformation.getServiceName(), serviceInformation.isSecureConnection(), requestInformation.getMaxConnectionTimeout(), requestInformation.getMaxReadTimeout())) {
-            icapSocket.write("OPTIONS icap://" + serviceInformation.getHostName() + ":" + serviceInformation.getServicePort() + "/" + serviceInformation.getServiceName() + " ICAP/" + requestInformation.getApiVersion() + NEWLINE 
+            icapSocket.write("OPTIONS icap://" + serviceInformation.getHostName() + ":" + serviceInformation.getServicePort() + "/" + serviceInformation.getServiceName() + " ICAP/" + requestInformation.getApiVersion() + NEWLINE
                              + "Host: " + serviceInformation.getHostName() + NEWLINE
                              + "User-Agent: " + requestInformation.getUserAgent() + NEWLINE
                              + createCustomHeaders(requestInformation)
                              + ICAPConstants.HEADER_KEY_ENCAPSULATED + ": null-body=0" + NEWLINE + NEWLINE);
             icapSocket.flush();
 
-            ICAPHeaderInformation icapHeaderInformation = icapSocket.readICAPResponse(requestIdentifier, ICAP_END_SEPARATOR, bufferSize); 
+            ICAPHeaderInformation icapHeaderInformation = icapSocket.readICAPResponse(requestIdentifier, ICAP_END_SEPARATOR, bufferSize);
             if (icapHeaderInformation.getStatus() != 200) {
                 throw new IOException("Could not resolve options!");
             }
-            
+
             int serverPreviewSize = 1024;
-            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_PREVIEW) 
-                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW) != null 
+            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_PREVIEW)
+                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW) != null
                     && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW).size() > 0) {
                 try {
                     serverPreviewSize = Integer.parseInt(icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_PREVIEW).get(0));
@@ -128,17 +124,17 @@ public class ICAPClientImpl implements ICAPClient {
             }
 
             boolean serverAllow204 = false;
-            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_ALLOW) 
-                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ALLOW) != null 
+            if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_ALLOW)
+                    && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ALLOW) != null
                     && icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ALLOW).size() > 0) {
                 serverAllow204 = Boolean.valueOf(icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ALLOW).get(0).equalsIgnoreCase("204"));
             }
-            
-            LOG.info(requestIdentifier + "Valid service [" 
+
+            LOG.info(requestIdentifier + "Valid service ["
                      + icapHeaderInformation.getStatus() + "/" + icapHeaderInformation.getMessage() + "], "
                      + "allow 204: " + serverAllow204 + ", "
                      + "available methods: " + icapHeaderInformation.getHeaderValues("Methods"));
-            
+
             int i = 0;
             ICAPMode[] result = new ICAPMode[icapHeaderInformation.getHeaderValues("Methods").size()];
             for (String method : icapHeaderInformation.getHeaderValues("Methods")) {
@@ -155,7 +151,7 @@ public class ICAPClientImpl implements ICAPClient {
 
 
     /**
-     * @see com.github.toolarium.icap.client.ICAPClient#validateResource(com.github.toolarium.icap.client.dto.ICAPMode, com.github.toolarium.icap.client.dto.ICAPResource)
+     * @see ICAPClient#validateResource(ICAPMode, ICAPResource)
      */
     @Override
     public ICAPHeaderInformation validateResource(final ICAPMode mode, final ICAPResource resource) throws IOException, ContentBlockedException {
@@ -164,7 +160,7 @@ public class ICAPClientImpl implements ICAPClient {
 
 
     /**
-     * @see com.github.toolarium.icap.client.ICAPClient#validateResource(com.github.toolarium.icap.client.dto.ICAPMode, com.github.toolarium.icap.client.dto.ICAPRequestInformation, com.github.toolarium.icap.client.dto.ICAPResource)
+     * @see ICAPClient#validateResource(ICAPMode, ICAPRequestInformation, ICAPResource)
      */
     @Override
     public ICAPHeaderInformation validateResource(final ICAPMode inputMode, final ICAPRequestInformation requestInformation, final ICAPResource resource) throws IOException, ContentBlockedException {
@@ -195,11 +191,11 @@ public class ICAPClientImpl implements ICAPClient {
         }
 
         File resourceResponse = File.createTempFile(requestIdentifier, ".tmp");
-        try (ICAPSocket icapSocket = new ICAPSocket(connectionManager, requestIdentifier, serviceInformation.getHostName(), serviceInformation.getServicePort(), 
+        try (ICAPSocket icapSocket = new ICAPSocket(connectionManager, requestIdentifier, serviceInformation.getHostName(), serviceInformation.getServicePort(),
                                                     serviceInformation.getServiceName(), serviceInformation.isSecureConnection(), requestInformation.getMaxConnectionTimeout(), requestInformation.getMaxReadTimeout())) {
             ICAPHeaderInformation icapHeaderInformation = processResource(requestIdentifier, icapSocket, icapMode, requestInformation, resource, resourceResponse);
             icapHeaderInformation.getHeaders().remove(ICAPConstants.HEADER_KEY_X_ICAP_STATUSLINE);
-            
+
             if (icapHeaderInformation.getStatus() == 200) {
                 String threadInformation = "";
 
@@ -208,19 +204,19 @@ public class ICAPClientImpl implements ICAPClient {
                         threadInformation += "- " + e.getKey() + ": " + e.getValue() + "\n";
                     }
                 }
-                
+
                 // verify if there is a thread is found taken from header
                 if (hasThreadHeaderInformation(icapHeaderInformation)) {
                     String threadHeaderInformation = readThreadHeaderInformation(icapMode, icapHeaderInformation, resourceResponse);
                     String msg = "Threat found in resource (" + sourceRequest + ", http-status: " + icapHeaderInformation.getStatus() + "):\n" + threadInformation.trim();
                     LOG.info(requestIdentifier + msg);
-                    throw new ContentBlockedException(msg, icapHeaderInformation, threadHeaderInformation);                    
-                } else if (supportCompareVerifyIdenticalContent 
+                    throw new ContentBlockedException(msg, icapHeaderInformation, threadHeaderInformation);
+                } else if (supportCompareVerifyIdenticalContent
                         && icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_IDENTICAL_CONTENT) && !icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_X_IDENTICAL_CONTENT).isEmpty()
                         && !Boolean.valueOf(icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_X_IDENTICAL_CONTENT).get(0))) {
                     String msg = "Not identical resource (" + sourceRequest + ", http-status: " + icapHeaderInformation.getStatus() + "):\n" + threadInformation.trim();
                     LOG.info(requestIdentifier + msg);
-                    throw new ContentBlockedException(msg, icapHeaderInformation);                    
+                    throw new ContentBlockedException(msg, icapHeaderInformation);
                 }
             }
 
@@ -236,10 +232,10 @@ public class ICAPClientImpl implements ICAPClient {
         }
     }
 
-    
+
     /**
      * Create custom headers
-     * 
+     *
      * @param requestInformation the ICAP request information
      * @return the customer headers
      */
@@ -247,43 +243,43 @@ public class ICAPClientImpl implements ICAPClient {
         if (requestInformation.getCustomHeaders() == null || requestInformation.getCustomHeaders().isEmpty()) {
             return "";
         }
-        
+
         final StringBuilder headers = new StringBuilder();
         for (Map.Entry<String, String> e : requestInformation.getCustomHeaders().entrySet()) {
             final String key = e.getKey().trim();
             final String value = e.getValue().trim();
-            
+
             if (key.equalsIgnoreCase("Host") || key.equalsIgnoreCase("Connection") || key.equalsIgnoreCase("User-Agent") || key.equalsIgnoreCase("Preview") || key.equalsIgnoreCase("Encapsulated") || key.equalsIgnoreCase("Allow")) {
                 LOG.warn("Invalid customer header [" + key + "], it's not allowed, ignore!");
             } else if (!value.isEmpty()) {
                 headers.append(key).append(": ").append(value).append(NEWLINE);
             }
         }
-        
+
         return headers.toString();
     }
 
-    
+
     /**
      * Check if there are thread header information
-     * 
+     *
      * @param icapHeaderInformation the ICAP header information
      * @return true if a thread was detected
      */
     private boolean hasThreadHeaderInformation(ICAPHeaderInformation icapHeaderInformation) {
-        return icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_INFECTION_FOUND) 
+        return icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_INFECTION_FOUND)
                || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIOLATIONS_FOUND)
-               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCKED)        // used by Sophos                 
-               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_ID)       // used by Sophos, Kaspersky, Trenxd Micro, ESET, McAfee, C-ICAP                 
-               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_NAME)     // used by McAfee                 
-               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_REASON)   // used by McAfee                 
-               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_RESULT);  // used by McAfee                 
+               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCKED)        // used by Sophos
+               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_ID)       // used by Sophos, Kaspersky, Trenxd Micro, ESET, McAfee, C-ICAP
+               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_NAME)     // used by McAfee
+               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_REASON)   // used by McAfee
+               || icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCK_RESULT);  // used by McAfee
     }
 
-    
+
     /**
      * Read the thread reason
-     * 
+     *
      * @param icapMode the icap mode
      * @param resourceResponse the resource response
      * @param icapHeaderInformation the ICAP header information
@@ -293,7 +289,7 @@ public class ICAPClientImpl implements ICAPClient {
         String threadHeaderInformation = null;
 
         if (icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_ENCAPSULATED) && !icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ENCAPSULATED).isEmpty()
-            && resourceResponse != null && resourceResponse.length() > 0 && resourceResponse.exists()) {                    
+            && resourceResponse != null && resourceResponse.length() > 0 && resourceResponse.exists()) {
             for (int i = 0; i < icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ENCAPSULATED).size(); i++) {
                 String entry = icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_ENCAPSULATED).get(i);
                 String[] split = entry.split("=");
@@ -303,45 +299,45 @@ public class ICAPClientImpl implements ICAPClient {
                     } catch (IOException e) {
                         LOG.warn("Could not read resource response: " + e.getMessage(), e);
                     }
-                    
+
                     break;
                 }
             }
         }
-        
+
         if ((threadHeaderInformation == null || threadHeaderInformation.isBlank()) && icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_BLOCKED)) {
             // used by Sophos
             threadHeaderInformation = "" + icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_X_BLOCKED);
         }
-        
+
         if ((threadHeaderInformation == null || threadHeaderInformation.isBlank()) && icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_ID)) {
             // used by Sophos, Kaspersky, Trenxd Micro, ESET, McAfee, C-ICAP
             threadHeaderInformation = "" + icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_X_VIRUS_ID);
         }
-        
+
         if ((threadHeaderInformation == null || threadHeaderInformation.isBlank()) && icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_X_VIRUS_NAME)) {
             // used by McAfee
             threadHeaderInformation = "" + icapHeaderInformation.getHeaderValues(ICAPConstants.HEADER_KEY_X_VIRUS_NAME);
         }
-   
+
         if (threadHeaderInformation == null || threadHeaderInformation.isBlank()) {
             threadHeaderInformation = "n/a";
         }
-        
+
         return threadHeaderInformation;
     }
 
-    
+
     /**
      * Validate resource
-     * 
+     *
      * @param resource the resource
      * @throws IOException In case of an invalid resource
      */
     protected void validateICAPResource(final ICAPResource resource) throws IOException {
-        if (resource == null 
-                || resource.getResourceName() == null || resource.getResourceName().isBlank() 
-                || resource.getResourceBody() == null 
+        if (resource == null
+                || resource.getResourceName() == null || resource.getResourceName().isBlank()
+                || resource.getResourceBody() == null
                 || resource.getResourceLength() <= 0) {
             throw new IOException("Invalid input resource!");
         }
@@ -359,12 +355,13 @@ public class ICAPClientImpl implements ICAPClient {
      * @param resourceResponse the resource response
      * @return the ICAP header information
      * @throws IOException In case of an I/O error
+     * @throws UnknownIOException In case of an unknown I/O error
      * @throws ContentBlockedException In case the content is blocked
      */
     protected ICAPHeaderInformation processResource(final String requestIdentifier,
-                                                    final ICAPSocket icapSocket, 
+                                                    final ICAPSocket icapSocket,
                                                     final ICAPMode icapMode,
-                                                    final ICAPRequestInformation requestInformation, 
+                                                    final ICAPRequestInformation requestInformation,
                                                     final ICAPResource resource,
                                                     final File resourceResponse) throws IOException, ContentBlockedException {
 
@@ -372,7 +369,7 @@ public class ICAPClientImpl implements ICAPClient {
         String httpMethod = "GET";
         String header = httpMethod + " /" + URLEncoder.encode(resource.getResourceName().trim(), StandardCharsets.UTF_8.name()) + " HTTP/1.1" + NEWLINE
                         + "Host: " + requestInformation.getRequestSource() + NEWLINE + NEWLINE;
-        String body = header + "HTTP/1.1 200 OK" + NEWLINE + ICAPConstants.HEADER_KEY_TRANSFER_ENCODING + ": chunked" + NEWLINE 
+        String body = header + "HTTP/1.1 200 OK" + NEWLINE + ICAPConstants.HEADER_KEY_TRANSFER_ENCODING + ": chunked" + NEWLINE
                       + ICAPConstants.HEADER_KEY_CONTENT_LENGTH + ": " + resource.getResourceLength() + NEWLINE + NEWLINE;
         String reqHdr = "";
         String bodyHdr = "";
@@ -388,23 +385,23 @@ public class ICAPClientImpl implements ICAPClient {
             previewSize = (int) resource.getResourceLength();
         }
 
-        String requestBuffer = "" + icapMode.name() + " icap://" + serviceInformation.getHostName() + ":" + serviceInformation.getServicePort() + "/" + serviceInformation.getServiceName() + " ICAP/" + requestInformation.getApiVersion() + NEWLINE 
+        String requestBuffer = "" + icapMode.name() + " icap://" + serviceInformation.getHostName() + ":" + serviceInformation.getServicePort() + "/" + serviceInformation.getServiceName() + " ICAP/" + requestInformation.getApiVersion() + NEWLINE
                              + "Host: " + serviceInformation.getHostName() + NEWLINE
-                             + "Connection:  close" + NEWLINE 
-                             + "User-Agent: " + requestInformation.getUserAgent() + NEWLINE 
+                             + "Connection:  close" + NEWLINE
+                             + "User-Agent: " + requestInformation.getUserAgent() + NEWLINE
                              + createCustomHeaders(requestInformation)
                              + supportAllow204(requestIdentifier, requestInformation.isAllow204())
-                             + "Preview: " + previewSize + NEWLINE 
-                             + "Encapsulated: " + reqHdr + bodyHdr + icapMode.getTag() + "-body=" + body.length() + NEWLINE + NEWLINE 
+                             + "Preview: " + previewSize + NEWLINE
+                             + "Encapsulated: " + reqHdr + bodyHdr + icapMode.getTag() + "-body=" + body.length() + NEWLINE + NEWLINE
                              + body
                              + Integer.toHexString(previewSize) + NEWLINE;
         icapSocket.write(requestBuffer);
 
         // sending preview or, if smaller than previewSize, the whole file.
         byte[] chunk = new byte[previewSize];
-        
+
         MessageDigest inputMessageDigest = ICAPClientUtil.getInstance().createMessageDigest(messageDigestAlgorithm);
-        DigestInputStream inputstream = new DigestInputStream(resource.getResourceBody(), inputMessageDigest); 
+        DigestInputStream inputstream = new DigestInputStream(resource.getResourceBody(), inputMessageDigest);
         int readBytes = inputstream.read(chunk);
         long totalReadBytes = readBytes;
         icapSocket.write(chunk, 0, readBytes);
@@ -425,7 +422,7 @@ public class ICAPClientImpl implements ICAPClient {
                 case 200: return icapHeaderInformation;
                 case 204: return icapHeaderInformation;
                 case 404: throw new IOException("404: ICAP Service not found");
-                default: throw new IOException("Server returned unknown status code:" + icapHeaderInformation.getStatus());
+                default: throw new UnknownIOException("Server returned unknown status code:" + icapHeaderInformation.getStatus(), icapHeaderInformation);
             }
         }
 
@@ -434,7 +431,7 @@ public class ICAPClientImpl implements ICAPClient {
             byte[] buffer = new byte[bufferSize];
             readBytes = -1;
             while ((readBytes = inputstream.read(buffer)) != -1) {
-                totalReadBytes += readBytes;               
+                totalReadBytes += readBytes;
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(requestIdentifier + "Send next block of " + readBytes + " bytes (total sent: " + totalReadBytes + " bytes)...");
                 }
@@ -442,22 +439,22 @@ public class ICAPClientImpl implements ICAPClient {
                 icapSocket.write(buffer, 0, readBytes);
                 icapSocket.write(NEWLINE);
             }
-            
+
             // closing resource transfer.
             icapSocket.write(HTTP_END_SEPARATOR);
             icapSocket.flush();
         }
-        
+
         ICAPHeaderInformation icapHeaderInformation = icapSocket.readICAPResponse(requestIdentifier, ICAP_END_SEPARATOR, bufferSize);
         if (icapHeaderInformation.getStatus() == 204) { // unmodified
             return icapHeaderInformation;
-        } 
+        }
 
         if (icapHeaderInformation.getStatus() == 200) { // OK - The ICAP status is ok, but the encapsulated HTTP status will likely be different
             if ((requestInformation.isAllow204() != null && !requestInformation.isAllow204()) && ICAPMode.REQMOD.equals(icapMode)) {
                 return icapHeaderInformation;
             }
-            
+
             if (!icapHeaderInformation.containsHeader(ICAPConstants.HEADER_KEY_ENCAPSULATED)) {
                 LOG.warn("Missing " + ICAPConstants.HEADER_KEY_ENCAPSULATED + " information!");
                 return icapHeaderInformation;
@@ -473,16 +470,16 @@ public class ICAPClientImpl implements ICAPClient {
             }
             icapSocket.flush();
             icapSocket.close();
-            
+
             String inputMsg = ICAPClientUtil.getInstance().messageDigestToString(messageDigestAlgorithm, inputMessageDigest);
             icapHeaderInformation.getHeaders().put(ICAPConstants.HEADER_KEY_X_REQUEST_MESSAGE_DIGEST, Arrays.asList(inputMsg));
-            String outputMsg = ICAPClientUtil.getInstance().messageDigestToString(messageDigestAlgorithm, outputMessageDigest);            
+            String outputMsg = ICAPClientUtil.getInstance().messageDigestToString(messageDigestAlgorithm, outputMessageDigest);
             icapHeaderInformation.getHeaders().put(ICAPConstants.HEADER_KEY_X_RESPONSE_MESSAGE_DIGEST, Arrays.asList(outputMsg));
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug(requestIdentifier + "Resource length: " + resource.getResourceLength() + ", Response length: " + resourceResponse.length() + "?");
             }
-            
+
             if (supportCompareVerifyIdenticalContent) {
                 boolean identicalContent = couldProcessFullContent && resource.getResourceLength() == resourceResponse.length() && inputMsg.equals(outputMsg);
                 if (identicalContent) {
@@ -495,23 +492,23 @@ public class ICAPClientImpl implements ICAPClient {
 
             return icapHeaderInformation;
         }
-        
-        throw new IOException("Unrecognized or no status code in response header: " + icapHeaderInformation.getStatus() + "!");
+
+        throw new UnknownIOException("Unrecognized or no status code in response header: " + icapHeaderInformation.getStatus() + "!", icapHeaderInformation);
     }
 
 
     /**
      * Check allow 204 support
-     * 
+     *
      * @param requestIdentifier the equest identifier
      * @param isAllow204 the request information
      * @return the request string
      */
     protected String supportAllow204(final String requestIdentifier, final Boolean isAllow204) {
-        
-        String serverReason = "suppported by the icap-server";    
+
+        String serverReason = "suppported by the icap-server";
         if (!remoteServiceConfiguration.isServerAllow204()) {
-            serverReason = "not " + serverReason;    
+            serverReason = "not " + serverReason;
         }
 
         String requestReason = "requested";
@@ -527,17 +524,17 @@ public class ICAPClientImpl implements ICAPClient {
             selectAllow204Reason = "Use allow 204";
             allow204Request = "Allow: 204" + NEWLINE;
         }
-        
+
         if (LOG.isDebugEnabled()) {
             LOG.debug(requestIdentifier + selectAllow204Reason + ": " + requestReason + " (" + serverReason + ")");
         }
         return allow204Request;
     }
 
-    
+
     /**
      * Create request identifier
-     * 
+     *
      * @param mode the mode
      * @param sourceRequest the source request
      * @return the request identifier
@@ -549,7 +546,7 @@ public class ICAPClientImpl implements ICAPClient {
 
     /**
      * Validate the request information
-     * 
+     *
      * @param requestInformation the request information
      * @throws IOException In case of an invalid request information
      */


### PR DESCRIPTION
Some vendor's ICAP server is returning HTTP 500 however there is information in the response headers that identifies why the content was rejected.  This change adds capability to access the headers in the UnknownIOException.